### PR TITLE
Template updates

### DIFF
--- a/templates/DataModel-1.0.tt
+++ b/templates/DataModel-1.0.tt
@@ -164,7 +164,7 @@
         }
         if (!string.IsNullOrWhiteSpace(property.DefaultValue)) { Write(", DefaultValue = " + property.DefaultValue); }
         if (property.AutomaticType != AutomaticType.None) { Write(", AutomaticType = AutomaticType." + Convert.ToString(property.AutomaticType)); }
-        if (property.Protection != ProtectionType.None) { Write(", Protection = ProtectionType." + Convert.ToString(property.Protection)); }
+        if (property.Protection != ProtectionType.None) { Write(", Protection = " + ToProtectionTypeString(property.Protection)); }
 
         if (!string.IsNullOrWhiteSpace(modelLabelsType))
         {
@@ -176,7 +176,7 @@
         }
         else 
         {
-            Write(", Caption = \"" + property.Caption + "\"");
+            if (!string.IsNullOrWhiteSpace(property.Caption)) { Write(", Caption = \"" + property.Caption + "\""); }
             if (!string.IsNullOrWhiteSpace(property.Hint)) { Write(", Hint = \"" + property.Hint + "\""); }
             if (!string.IsNullOrWhiteSpace(property.MandatoryMessage)) { Write(", RequiredMessage = \"" + property.MandatoryMessage + "\""); }
             if (!string.IsNullOrWhiteSpace(property.InvalidContentMessage)) { Write(", InvalidContentMessage = \"" + property.InvalidContentMessage + "\""); }
@@ -334,7 +334,6 @@
     WriteLine("/// <summary>");
     WriteLine("/// Whether validation must be enforced.");
     WriteLine("/// </summary>");
-    WriteLine("[Editable(false)]");
     WriteLine("public override bool EnforceModelValidation => " + (Source.EnforceModelValidation ? "true;" : "false;"));
 
     // constructors

--- a/templates/Lib/Commons.tt
+++ b/templates/Lib/Commons.tt
@@ -358,6 +358,15 @@
         }));
     }
 
+    // converts the protection type
+    protected virtual string ToProtectionTypeString(ProtectionType protection)
+    {
+        return protection == ProtectionType.None ? "ProtectionType.None" 
+             : protection == ProtectionType.Encrypted ? "ProtectionType.Encrypted"
+             : protection == ProtectionType.Hashed ? "ProtectionType.Hashed"
+             : "ProtectionType.Password";
+    }
+
     // converts the relation operator into a text representing the a RelationalOperator enum.
     protected virtual string ToRelationalOperatorEnumText(RelationOperator relation)
     {


### PR DESCRIPTION
#### Classification
Minor template updates.

#### Summary
This pull request introduces some minor adjustments on templates.
- `DataModel-10.tt`: uses a new method to compute a property protection type and avoids to write the caption when no one is available.
- `Commons.tt`: adds a new method to compute the protection type including the use of the fixed encrypted type from the framework last version.
